### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -4,12 +4,18 @@ provider "google" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "ai-demo-bucket-${random_id.random.hex}"
-  location = "EU"
+  name                        = "ai-demo-bucket-${random_id.random.hex}"
+  location                    = "EU"
   uniform_bucket_level_access = true
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "ai-demo-logs-bucket-${random_id.random.hex}"
+    log_object_prefix = "logs"
+  }
 }
 
 resource "random_id" "random" {
   byte_length = 3
 }
-


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 8f9f07f20820d5dea9b9b97496f995a14e61c61b
**Description:** The changes in this pull request involve updates to the Terraform configuration for a Google Cloud Storage (GCS) bucket. The updates include enabling object versioning and setting up logging for the storage bucket.

**Summary:** 
- `gcs.tf` (modified) - The GCS bucket configuration now includes `versioning` and `logging` blocks. Versioning is enabled, which means that previous versions of objects are kept in the bucket. Logging is configured to write logs to a specified bucket with a log prefix.

**Recommendations:** 
- Ensure that the logging bucket (`ai-demo-logs-bucket-${random_id.random.hex}`) exists and has the appropriate permissions for writing logs. 
- Verify that enabling versioning aligns with the data lifecycle policies and storage cost implications.
- Test the logging to confirm that logs are being generated and stored as expected.
- Consider adding a newline at the end of the file to adhere to POSIX standards.

**Explicação de Vulnerabilidades:** 
- No immediate security vulnerabilities are apparent in the changes made. However, enabling logging and versioning should be carefully considered from a data governance and cost perspective. Ensure that proper access controls are in place for the logging bucket to prevent unauthorized access to logs, which may contain sensitive information. 
- Review the bucket's IAM policies to ensure that only authorized users can read and write to the versioned objects to prevent potential data leakage or unauthorized data restoration.