### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -1,21 +1,20 @@
 provider "google" {
   project = "dev-env-1-412811"
-  region  = "europe-west1"
+}
+
+resource "random_id" "bucket_id" {
+  byte_length = 8
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket"
-  project  = "dev-env-1-412811"
-
+  name                        = "ai-demo-${random_id.bucket_id.hex}"
+  location                    = "EU"
   uniform_bucket_level_access = true
-
-  lifecycle_rule {
-    action {
-      type = "Delete"
-    }
-
-    condition {
-      age = 7
-    }
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "ai-demo-logs-${random_id.bucket_id.hex}"
+    log_object_prefix = "log"
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 12d4ff36e5acd910ad80d16c8266d5b1ef5a2a80
**Description:** The changes in this pull request involve updates to the Google Cloud Storage (GCS) Terraform configuration. The updates include removal of static bucket naming and region configuration, introduction of random ID generation for bucket names, setting the bucket location to Europe, enabling versioning, and configuring logging for the bucket.

**Summary:**
- `gcs.tf` (modified) - Modified the Terraform configuration for provisioning a Google Cloud Storage bucket. The static name and project assignment have been removed. Instead, a `random_id` resource is introduced to generate a unique identifier for the bucket name. The bucket location is now explicitly set to "EU". The previous lifecycle rule for deleting objects older than 7 days has been removed, and instead, versioning is enabled to keep a history of object changes. Additionally, logging configuration has been added to store logs in a separate bucket with a prefix.

**Recommendations:** The reviewer should ensure that the newly introduced random ID generation meets the naming conventions and requirements for the project. It's also important to confirm that the removal of the lifecycle rule aligns with the data retention policy of the project. Since versioning is enabled, it should be verified that appropriate policies and access controls are in place to manage object versions. Lastly, check that the logging configuration is set up correctly and that the specified log bucket exists and is accessible.

(Not applicable, since no new vulnerabilities were introduced and no existing vulnerabilities were directly addressed in this commit) **Explanation of Vulnerabilities:** N/A

Please note, the lack of a newline at the end of the file is not an issue with Terraform files, but it's generally good practice to include a newline at the end of code files to comply with POSIX standards.