### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -7,6 +7,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "EUROPE-WEST1"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 0f24e673282067388ed57afeed53a8116614f9bf
**Description:** This pull request introduces changes to the `gcs.tf` Terraform configuration file which enable versioning and logging for a Google Cloud Storage (GCS) bucket.

**Summary:**
- `gcs.tf` (modified) - The Terraform configuration for a GCS bucket has been updated to include:
  - A `versioning` block to enable object versioning within the bucket. This ensures that every update to an object in the bucket is kept as a separate version, which can be useful for data recovery and change tracking.
  - A `logging` block to enable access and storage logs for the bucket. The logs will be stored in a separate bucket named `my-logs-bucket` with a log object prefix of `log`. This aids in monitoring and analyzing access patterns or potential security incidents.

**Recommendations:** The reviewer should verify the following:
- Ensure that the `my-logs-bucket` for logging exists and has the appropriate permissions set up to receive logs from the `my-bucket-1672`.
- Confirm if the versioning and logging features align with the project's data retention and access policies.
- Check if any additional costs are incurred due to versioning and logging and if it fits within the budget.
- Suggest running a Terraform plan to ensure no unintended changes are being made and that the changes are compatible with the existing infrastructure setup.

**Explicação de Vulnerabilidades:** Not applicable, as no security vulnerabilities are introduced or addressed in this specific change. However, enabling logging is a good security practice as it provides an audit trail. It's important to ensure that the logging bucket itself is secured and access to the logs is appropriately restricted.