### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -5,8 +5,13 @@ provider "google" {
 
 resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
-
-
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 83348632754e17432b22869bc9dea75834fdcb94
**Description:** This update introduces versioning and logging features to the existing Google Cloud Storage bucket defined in the Terraform configuration. The versioning feature keeps a history of object versions, allowing recovery from accidental deletions or overwrites. The logging feature captures access and usage logs, storing them in a specified log bucket with a defined log object prefix.

**Summary:** 
- `gcs.tf` (modified) - The `google_storage_bucket` resource named "bucket" has been updated to include:
  - A `versioning` block that enables object versioning within the bucket.
  - A `logging` block that specifies "my-logs-bucket" as the destination bucket for access and usage logs and sets "log" as the prefix for log object names.
  - No changes have been made to the `uniform_bucket_level_access` which remains enabled, ensuring uniform access control across all objects in the bucket.
  - The `lifecycle_rule` block is unchanged and not shown in the diff snippet provided.

**Recommendations:**
- Verify that "my-logs-bucket" exists and has the appropriate permissions set to receive logs.
- Ensure that enabling versioning aligns with the data retention and storage cost policies of the project.
- Test the updated configuration in a development or staging environment to confirm that the versioning and logging features are working as expected.
- Review the lifecycle policies to ensure they are compatible with the newly enabled versioning feature, as it can affect object deletion and archival processes.

(No mention of vulnerabilities within the provided information, so no vulnerability explanation is necessary.)