### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -7,6 +7,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "EU"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 26e2da9f607f54635ad357d8481bb20bec86bd27
**Description:** This pull request introduces enhancements to the Google Cloud Storage (GCS) Terraform configuration by enabling versioning for the storage bucket and setting up logging with a specific bucket and object prefix.

**Summary:**
- `gcs.tf` (modified) - Added a `versioning` block to enable versioning for the bucket, which allows for the preservation, retrieval, and restoration of every version of every object stored in the Google Storage bucket. Moreover, a `logging` block was added to define the destination bucket and object prefix for access logs, which allows for the collection and analysis of access logs for the bucket.

**Recommendations:** The reviewer should verify that enabling versioning and logging aligns with the project's requirements for data retention and access monitoring. It's important to ensure that the specified log bucket (`my-logs-bucket`) exists and has the appropriate permissions set up to receive logs. Additionally, consider the implications of versioning on storage costs, as all versions of an object are stored. Automated tests should be updated or added to confirm that these new features function as expected.

- Ensure that the bucket `my-bucket-1672` is intended to have versioning enabled.
- Confirm that `my-logs-bucket` is the correct destination for storing logs, and check if the bucket exists with the proper permissions.
- Review the `log_object_prefix` value to ensure it meets the naming conventions and organizational requirements.
- Check for any potential increase in costs due to the enabled versioning and ensure that budget considerations have been accounted for.