### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -4,8 +4,13 @@ provider "google" {
 
 resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
-
-
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
```markdown
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the ab59c89fb269f075f99507300104463efcb0f5ae
**Description:** This pull request introduces changes to the `gcs.tf` Terraform configuration file. Specifically, it adds configuration for object versioning and access logging for the Google Cloud Storage bucket.

**Summary:**
- `gcs.tf` (modified) - The existing Google Storage bucket resource named "my-bucket-1672" has been updated with two new blocks. The first block enables versioning to keep a history of objects in the bucket, which is useful for data recovery and protection against unintended overwrites and deletions. The second block configures logging, specifying "my-logs-bucket" as the destination bucket for access logs and "log" as the prefix for log object names. Additionally, the `uniform_bucket_level_access` is set to `true`, which enforces uniform access controls on the bucket, meaning that only IAM policies will be used to grant permissions and not legacy bucket ACLs.

**Recommendations:** The reviewer should ensure that the "my-logs-bucket" exists and has the appropriate permissions set up to receive log files from "my-bucket-1672". It is also important to ensure that enabling versioning aligns with the data lifecycle policies of the organization since it may lead to increased storage costs. Make sure to test the configuration changes in a non-production environment before applying them to production to avoid any unintended consequences.

(No vulnerabilities found in the current changes)
```