### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -6,6 +6,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "US"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
```markdown
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 2a72cea41e2ba562cc2847f0b752b24f61d8aaeb
**Description:** The changes in this pull request involve updates to the `gcs.tf` file, which is used to define configurations for a Google Cloud Storage (GCS) bucket. The updates include enabling versioning for the bucket and adding logging configurations.

**Summary:**
- gcs.tf (modified) - Versioning has been enabled for the GCS bucket to keep a history of object versions, which allows for recovery from accidental deletions or overwrites. Logging has also been added, specifying a separate bucket for storing logs and a prefix for log object names.

**Recommendations:** The reviewer should ensure that the bucket intended for logs (`my-logs-bucket`) has been created and has the appropriate permissions set. It's important to verify that enabling versioning aligns with the storage cost and object lifecycle policies, as it can increase storage usage. Additionally, check that the logging settings do not expose any sensitive data and that the log bucket's access control is configured correctly. Testing should include verifying that versioning and logging are functioning as expected.

**Explicação de Vulnerabilidades:** Not applicable as no direct security vulnerabilities are indicated by the changes in this commit.
```