### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -6,6 +6,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "US"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the c5e49ea72334d8b859e0b7337120716754b86fd9
**Description:** The changes introduce versioning and logging features to a Google Cloud Storage (GCS) bucket configuration in Terraform.

**Summary:** 
- `gcs.tf` (modified) - The Terraform configuration file named `gcs.tf` has been updated to include a `versioning` block that enables object versioning within the GCS bucket. This is a feature that keeps a history of versions for each object in the bucket, allowing recovery of previous versions. Additionally, a `logging` block has been added to specify that access logs should be stored in a separate bucket named "my-logs-bucket" with the log file prefix "log". This is used for access and audit logging.

**Recommendations:** The reviewer should ensure that the bucket for logs "my-logs-bucket" is properly set up and has the correct permissions for the main bucket to write logs to it. Also, verify that enabling versioning aligns with the storage cost implications and the project's data management policies. It is recommended to test these new configurations in a controlled environment before applying to production to avoid any unexpected charges or behaviors.

**Explicação de Vulnerabilidades:** Not applicable, as the changes don't introduce any apparent security vulnerabilities. However, logging and versioning should be managed carefully to ensure they don't inadvertently expose sensitive data or lead to uncontrolled costs. Always make sure that proper access controls are in place for both the main bucket and the logs bucket.