### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -6,6 +6,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "US"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 7f10ac6540d421898b86b9c0361afc7457c54c09
**Description:** The pull request introduces versioning and logging features to the Google Cloud Storage bucket configuration in the `gcs.tf` Terraform file. It aims to enhance data retention and access log management for the storage bucket.

**Summary:**
- `gcs.tf` (modified) - The update includes a new `versioning` block that enables object versioning within the bucket, helping to preserve, retrieve, and restore every version of every object stored in the bucket. A `logging` block is also added to specify a separate bucket where access logs will be stored, with a prefix for the log objects.

**Recommendations:** The reviewer should check if the `my-logs-bucket` specified for logging exists and has the proper permissions set up to receive the log files. Additionally, it is important to ensure that enabling versioning aligns with the storage cost and data retention policies of the project. The reviewer should also validate if the `log_object_prefix` meets the naming conventions and organizational requirements. If the logging bucket or object prefix does not follow the expected naming conventions or does not exist, the reviewer should suggest appropriate changes.

**Note:** Enabling versioning on a storage bucket can increase costs as each version of an object is stored and billed separately. It's essential to consider lifecycle policies that can automatically delete older versions or transition them to cheaper storage classes to manage costs effectively.