### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -6,6 +6,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "US"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
```markdown
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the f147277c9ba557c99195dc3158eee05581f25b49
**Description:** This pull request introduces updates to the GCS Terraform configuration by enabling versioning for the storage bucket and adding logging configurations.

**Summary:**
- gcs.tf (modified) - The `google_storage_bucket` resource block has been updated to include a `versioning` block which enables object versioning. This means that overwritten or deleted objects will be preserved, allowing for recovery of previous versions. Additionally, a `logging` block has been added to specify that access logs will be stored in a separate bucket (`my-logs-bucket`) with a log prefix of "log". This will help in monitoring and auditing access to the `my-bucket-1672`.

**Recommendations:** The reviewer should verify that the bucket names (`my-bucket-1672` for the main bucket and `my-logs-bucket` for the logs) are correctly configured and exist within the project. Ensure that enabling versioning and access logging aligns with the data retention and access monitoring policies. Testing should involve deploying the changes to a test environment and validating that versioning and logging are functioning as expected.

(No vulnerabilities were explicitly mentioned or modified in the provided code snippet, hence no additional security vulnerability details are provided here.)
```
