### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -6,6 +6,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "US"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the fabbef9111739787e3089df7fa277fe2fb0b8cfe
**Description:** The changes in this pull request enhance the `google_storage_bucket` resource configuration within the Terraform file `gcs.tf`. Two new features are added: object versioning and access logs for the storage bucket.

**Summary:**
- `gcs.tf` (modified) - The Google Cloud Storage (GCS) bucket configuration has been updated with the following:
  - A `versioning` block has been introduced to enable object versioning, which keeps a history of changes to objects in the bucket, allowing recovery of older versions if necessary.
  - A `logging` block has been added to specify a separate bucket (`my-logs-bucket`) for storing access logs, with the prefix `log` for the log objects. This helps in monitoring requests and access patterns.

**Recommendations:** The reviewer should ensure that the bucket named `my-logs-bucket` for logging exists and has the appropriate permissions set up. Additionally, it would be good to verify if versioning should be enabled for all objects in the bucket, as this might have cost implications due to the storage of multiple object versions. Lastly, testing should be conducted to validate that the versioning and logging configurations work as expected.

**Explicação de Vulnerabilidades:** No specific security vulnerabilities were introduced or addressed with these changes. However, logging data may contain sensitive information, so proper access control policies should be in place to secure the log bucket. A recommendation would be to regularly audit the IAM permissions of the `my-logs-bucket` to ensure that only authorized users have access.