### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -6,6 +6,15 @@ resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
   location = "US"
 
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
+
   uniform_bucket_level_access = true
 
   lifecycle_rule {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the c83e501da54658dd65b739e528f63398bae50908
**Description:** The changes in this pull request involve the modification of the `gcs.tf` Terraform configuration file to enable versioning and logging for a Google Cloud Storage (GCS) bucket resource.

**Summary:**
- `gcs.tf` (modified) - The GCS bucket resource configuration now includes a `versioning` block that enables object versioning, allowing for the recovery of overwritten or deleted objects. Additionally, a `logging` block has been added to enable access logs, where `my-logs-bucket` is the destination bucket for the logs, and `log` is the prefix for log object names.

**Recommendations:** The reviewer should ensure that the bucket names used in the logging block, such as `my-logs-bucket`, are placeholders and should be replaced with actual bucket names before applying the configuration. Ensure that these buckets exist and have the correct permissions set up. Testing should verify that versioning and logging are working as expected. The reviewer might also want to consider the cost implications of enabling versioning and logging as these features can increase storage usage and therefore costs.

**Explicação de Vulnerabilidades:** No direct security vulnerabilities are introduced in the changes as per the provided code snippet. However, it's important to ensure that the logging bucket (`my-logs-bucket`) has appropriate access controls to prevent unauthorized access to the logs. The logs may contain sensitive information, and if the bucket is publicly accessible, it could lead to a data leak. The reviewer should verify that the logging bucket has restricted access only to authorized users or services.