### PR TITLE
[GFTCodeFix]:  Update on gcs.tf

### DIFF
--- a/gcs.tf
+++ b/gcs.tf
@@ -4,6 +4,14 @@ provider "google" {
 
 resource "google_storage_bucket" "bucket" {
   name     = "my-bucket-1672"
+  versioning {
+    enabled = true
+  }
+
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
 
   uniform_bucket_level_access = true
 
@@ -17,4 +25,3 @@ resource "google_storage_bucket" "bucket" {
     }
   }
 }
-#test


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the e145e4d6617d574ecffc0891fbb8a41b07ec1642
**Description:** The changes include enabling versioning and logging for a Google Cloud Storage bucket in the `gcs.tf` Terraform configuration file. Versioning allows for the retention of object versions, which can help in data recovery. Logging is configured to store logs in a specified bucket with a given object prefix.

**Summary:** 
- `gcs.tf` (modified) - Added a new `versioning` block to enable versioning for the storage bucket named "my-bucket-1672". A `logging` block was also added to specify "my-logs-bucket" as the bucket where logs should be stored, with "log" as the object prefix. The last change is the removal of a comment line and ensuring there is no newline at the end of the file.

**Recomendations:** Review the configurations to ensure the specified log bucket ("my-logs-bucket") exists and has the appropriate permissions set to receive logs. Confirm that the bucket versioning aligns with the data retention policies of the project. Additionally, ensure that enabling logging and versioning does not conflict with any security or cost management policies. The removal of the comment and newline at the end of the file seems unnecessary; consider keeping a newline at the end of Terraform files for better file formatting practices.

**Explanation of Vulnerabilities:** No explicit security vulnerabilities are introduced in this commit. However, it is important to ensure that the log bucket has secure access controls to prevent unauthorized access to the logs, which could contain sensitive information. Make sure that only authorized personnel have access to both the bucket and its logs. Always review and apply the principle of least privilege when setting permissions. 

```hcl
resource "google_storage_bucket" "bucket" {
  ...
  logging {
    log_bucket        = "my-logs-bucket"
    log_object_prefix = "log"
  }
  ...
}
```
Ensure the "my-logs-bucket" has proper ACLs/IAM policies to protect the log data.