### PR TITLE
[GFTCodeFix]:  Update on bucket.tf

### DIFF
--- a/bucket.tf
+++ b/bucket.tf
@@ -9,7 +9,12 @@ resource "random_id" "bucket_id" {
 resource "google_storage_bucket" "bucket" {
   name                        = "bucket-${random_id.bucket_id.hex}"
   location                    = "US"
-
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "bucket-${random_id.bucket_id.hex}-logs"
+    log_object_prefix = "log"
+  }
   uniform_bucket_level_access = true
 }
-#test


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 37d76273f7cf2336c413798a91efff091adc31e6
**Description:** The changes made to the `bucket.tf` Terraform configuration file involve enabling versioning and adding logging settings for the storage bucket. Versioning is a feature that keeps a history of object versions, which can be useful for data recovery and change tracking. The logging settings specify that access logs should be stored in a separate bucket with a specific naming convention for the log objects.

**Summary:** 
- `bucket.tf` (modified) - Added a `versioning` block to enable versioning for the storage bucket, ensuring that all object versions are preserved. Also, a `logging` block was added, defining `log_bucket` as the destination for access logs, and `log_object_prefix` as the prefix for the log objects.

**Recommendations:** 
- Reviewer should verify that the bucket naming convention for `log_bucket` matches the project's naming standards and that the logging bucket exists.
- Ensure the logging bucket has appropriate lifecycle policies to avoid excessive costs due to log storage.
- Check if versioning aligns with the data retention and backup policies of the project.
- Confirm that the `uniform_bucket_level_access` is set as per the project's access control policies.
- A newline at the end of the file is typically a good practice and can be considered to be added.

**Explication of Vulnerabilities:** 
- Not applicable as no explicit security vulnerabilities are introduced or addressed in the given changes. However, if the logging bucket (`log_bucket`) is not properly secured, it might lead to unauthorized access to access logs, which can contain sensitive information. Ensure that the logging bucket has strict access controls.