### PR TITLE
[GFTCodeFix]:  Update on bucket1.tf

### DIFF
--- a/bucket1.tf
+++ b/bucket1.tf
@@ -7,8 +7,14 @@ resource "random_id" "bucket_id" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = 
-
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
   uniform_bucket_level_access = true
 }


### PR DESCRIPTION
```markdown
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for a13df25d2becefc262f194cc48999198b14f28de
**Description:** The modifications in this pull request involve configuration changes to a Google Cloud Storage bucket defined in Terraform. Specifically, the bucket's location has been set, and versioning and logging configurations have been added.

**Summary:** 
- `bucket1.tf` (modified) - The `google_storage_bucket` resource has been updated with a defined location set to "US". Versioning has been enabled for the bucket, which will keep a history of object versions and allow for their retrieval. Additionally, logging has been configured for the bucket, with logs being stored in a separate bucket named "my-logs-bucket" and a log object prefix of "log". The `uniform_bucket_level_access` property remains set to true, ensuring consistent access controls across all objects in the bucket.

**Recommendations:** 
- Verify that the "US" location is appropriate for the bucket's intended use and complies with data sovereignty requirements.
- Ensure that the "my-logs-bucket" exists and has the proper permissions set up to receive log files from the bucket being configured.
- Confirm if enabling versioning aligns with the data lifecycle policies and storage cost implications.
- Consider adding a newline at the end of the file to follow best practices and POSIX standards.
- Test the Terraform configuration changes to ensure they apply successfully and the bucket behaves as expected with the new settings.

**Explicação de Vulnerabilidades:** Not applicable as no explicit security vulnerabilities have been introduced or modified in this commit.
```
