### PR TITLE
[GFTCodeFix]:  Update on bucket333.tf

### DIFF
--- a/bucket333.tf
+++ b/bucket333.tf
@@ -7,9 +7,14 @@ resource "random_id" "bucket_id" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = "US"
-  
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
   uniform_bucket_level_access = true
-
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 882db498498c0d80991c7f7676ec437b0e96e8a6
**Description:** The changes in this pull request involve updates to the Terraform configuration for a Google Cloud Storage bucket. The modifications include setting the bucket to have uniform bucket-level access, enabling versioning to keep a history of objects, and configuring logging to store logs in a specified bucket with a log prefix.

**Summary:**
- `bucket333.tf` (modified) - Updated the Google Cloud Storage bucket configuration to enable uniform bucket-level access, which applies permissions uniformly across all objects in the bucket. Added versioning to the bucket configuration, which keeps a history of object versions for recovery and archival purposes. Also, added logging configuration to specify a log bucket and a log object prefix, which determines where the access logs are stored and with what prefix the log object names will start.

**Recommendations:** Reviewer should verify that the bucket name `${random_id.bucket_id.hex}` follows the naming conventions and does not conflict with existing bucket names. Ensure that the 'US' location is appropriate for the use case and complies with data residency requirements. Check that the logging bucket "my-logs-bucket" exists and has the proper permissions set to receive log objects. It's also important to confirm that enabling versioning aligns with the data management strategy, as it may increase storage usage and costs. Additionally, test to confirm that the logging and versioning features work as expected after deployment.

**Explication of Vulnerabilities:** Not applicable as no immediate security vulnerabilities are evident from the changes made in this commit. However, always ensure that logging buckets are properly secured to prevent unauthorized access to access logs, which could contain sensitive information.