### PR TITLE
[GFTCodeFix]:  Update on bucket467.tf

### DIFF
--- a/bucket467.tf
+++ b/bucket467.tf
@@ -7,9 +7,14 @@ resource "random_id" "bucket_id" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = 
-  
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
   uniform_bucket_level_access = true
-
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 315f04ee92a73abda89c1249e7f1bd8c63dd7aee
**Description:** This commit introduces updates to the `bucket467.tf` Terraform configuration file for a Google Cloud Storage bucket. The updates include specifying a bucket location, enabling versioning to keep a history of object revisions, and setting up logging to capture access and usage data.

**Summary:** 
- `bucket467.tf` (modified) - The `google_storage_bucket` resource has been updated to set the bucket's location to "US". Versioning has been enabled to keep track of changes to objects within the bucket. Additionally, logging has been configured to store logs in "my-logs-bucket" with a log object prefix of "log". Finally, the `uniform_bucket_level_access` is set to `true` to enforce uniform access control across the bucket.

**Recommendations:** The reviewer should ensure that the location "US" is appropriate for the use case and complies with data residency requirements. Verify that enabling versioning aligns with the data lifecycle policies and that the costs associated with versioning are acceptable. Confirm the "my-logs-bucket" bucket exists and has the correct permissions set up to receive logs. Check for potential typos or naming inconsistencies. It might be good to include a lifecycle rule if versioning is enabled to avoid unnecessary costs due to accumulated old versions. Test to ensure that logging and versioning are functioning as expected.

(No explicit vulnerabilities were introduced or addressed in this commit, so no additional vulnerability explanation is necessary.)