### PR TITLE
[GFTCodeFix]:  Update on bucket88.tf

### DIFF
--- a/bucket88.tf
+++ b/bucket88.tf
@@ -7,8 +7,14 @@ resource "random_id" "bucket_id" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = 
-
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
   uniform_bucket_level_access = true
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for d6d85f983099f2206c1b7a45bd88fc59c9b7d404
**Description:** The pull request involves updates to the Terraform configuration file `bucket88.tf` which is used to manage a Google Cloud Storage bucket. The changes include setting a fixed location for the bucket, enabling versioning to keep a history of object changes, and configuring logging to capture access and usage data for the bucket.

**Summary:** 
- `bucket88.tf` (modified) - The `google_storage_bucket` resource has been updated with several properties:
  - The `location` attribute is now explicitly set to "US".
  - A `versioning` block has been added to enable versioning for the bucket.
  - A `logging` block has been introduced to specify a logging bucket and a log object prefix.
  - Ensured that `uniform_bucket_level_access` is set to true to enforce uniform access control across all objects in the bucket.

**Recommendations:** 
- Review the specified `location` to ensure it aligns with the infrastructure regional compliance and latency requirements.
- Confirm that the `my-logs-bucket` exists and has the appropriate permissions set up for storing logs.
- Validate that enabling versioning aligns with the data lifecycle policies and storage cost implications.
- Verify if the `log_object_prefix` "log" is appropriate and does not conflict with any existing object naming conventions.
- Suggest adding a newline at the end of the file to adhere to POSIX file standards.
- Test the configuration changes in a development or staging environment before applying to production.
- Ensure that all other related infrastructure components are updated accordingly to handle the new logging and versioning configurations.

**Explicação de Vulnerabilidades:** Not applicable as there are no explicit security vulnerabilities introduced by the changes in this commit. However, proper permissions and access controls should be verified for the logging bucket to prevent unauthorized access to the logs.