### PR TITLE
[GFTCodeFix]:  Update on bucket44.tf

### DIFF
--- a/bucket44.tf
+++ b/bucket44.tf
@@ -2,13 +2,20 @@ provider "google" {
   project = "dev-env-1-412811"
   region  = "us-central1"
 }
+
 resource "random_id" "bucket_id" {
   byte_length = 8
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = "US"
-
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
   uniform_bucket_level_access = true
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 371aa6ecf35512420dc03ba8fa691c19ad3ea69a
**Description:** The changes in this pull request involve updates to the Terraform configuration for a Google Cloud Storage bucket. The modifications include enabling uniform bucket-level access, adding versioning to the bucket, and setting up logging with a specified logs bucket and log object prefix.

**Summary:** 
- `bucket44.tf` (modified) - The Terraform configuration for `google_storage_bucket` named "bucket" was updated to enable uniform bucket-level access and versioning. Additionally, logging was configured with a designated logs bucket and a log object prefix. The name and location properties for the bucket remained unchanged, except for some formatting adjustments.

**Recommendations:** 
- Ensure that "my-logs-bucket" exists and that the necessary permissions are set up for writing logs.
- Confirm that enabling versioning aligns with the intended use case for this storage bucket, as it may impact storage costs.
- Validate the Terraform changes by performing a `terraform plan` to ensure no unexpected resources will be created or modified.
- It might be good practice to ensure that there is a newline at the end of the file to adhere to POSIX standards and to avoid potential issues with Unix-based tooling.

**Explicação de Vulnerabilidades:** Not applicable, as no explicit security vulnerabilities are introduced or addressed within the given changes. However, ensure that the logging bucket's permissions are correctly configured to prevent unauthorized access.