### PR TITLE
[GFTCodeFix]:  Update on bucket44.tf

### DIFF
--- a/bucket44.tf
+++ b/bucket44.tf
@@ -2,11 +2,19 @@ provider "google" {
   project = "dev-env-1-412811"
   region  = "us-central1"
 }
+
 resource "random_id" "bucket_id" {
   byte_length = 8
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = "US"
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the ffdf036cdb0b754119831033e17092d158f7f84c
**Description:** The changes in this pull request introduce versioning and logging features to an existing Google Cloud Storage bucket defined in the Terraform configuration file `bucket44.tf`.

**Summary:**
- `bucket44.tf` (modified) - The Google Cloud Storage bucket configuration now includes enabling versioning to keep a history of the object versions. Logging is also configured, directing where the access logs should be stored and their naming prefix. Specifically:
  - `versioning` block added to enable object versioning.
  - `logging` block added with `log_bucket` set to `"my-logs-bucket"` and `log_object_prefix` set to `"log"`.

**Recommendations:**
- Ensure that `"my-logs-bucket"` is an existing bucket intended for storing logs. If it's not created yet or not intended for this purpose, it might need to be updated.
- The logging feature will incur additional storage costs for the log objects; make sure this aligns with the budget and cost expectations.
- Verify if the bucket's location `"US"` is optimal for the users' and services' access patterns to minimize latency and costs.
- It's good practice to have a newline at the end of the file, so consider adding it.
- Review the IAM permissions for the bucket to ensure that only authorized users and services have access to the versioned objects and logs.
- As a security best practice, ensure that the access to logs is restricted to the necessary personnel or services.

**Explicação de Vulnerabilidades:**
- Não foram encontradas vulnerabilidades específicas neste commit. No entanto, sempre é importante garantir que as configurações de versionamento e logging sigam as melhores práticas de segurança e conformidade.