### PR TITLE
[GFTCodeFix]:  Update on bucket44.tf

### DIFF
--- a/bucket44.tf
+++ b/bucket44.tf
@@ -8,6 +8,13 @@ resource "random_id" "bucket_id" {
 }
 
 resource "google_storage_bucket" "bucket" {
-  name     = "my-bucket-${random_id.bucket_id.hex}"
-  location = "US"
+  name                        = "my-bucket-${random_id.bucket_id.hex}"
+  location                    = "US"
+  versioning {
+    enabled = true
+  }
+  logging {
+    log_bucket        = "my-logs-bucket"
+    log_object_prefix = "log"
+  }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the aec751dcba265d4a06d1d063567b4f9dc8079626
**Description:** This Pull Request introduces changes to the `bucket44.tf` Terraform configuration file that defines a Google Cloud Storage bucket. The modifications enable versioning for the bucket and configure logging to capture access and usage data, directing it to a specified logs bucket.

**Summary:**
- `bucket44.tf` (modified) - The existing Google Cloud Storage bucket definition has been updated to enable versioning, which preserves the history of objects in the bucket, allowing for restoration in case of accidental deletion or overwrites. Additionally, logging has been configured to store logs in a designated `my-logs-bucket` with a log object prefix of `"log"`.

**Recommendations:** 
- Ensure that the `my-logs-bucket` exists and has the correct permissions set up to receive logs. If this bucket is not set up properly, logging will not function as intended.
- Verify that versioning is indeed a requirement for this bucket, as enabling versioning can lead to increased storage costs due to multiple versions of objects being stored.
- Test the configuration changes to validate that versioning and logging work as expected. This can be done by uploading an object to the bucket, updating it, and then checking if the previous version is accessible. For logging, access the bucket and then verify that the access logs are correctly written to `my-logs-bucket`.
- There is no newline at the end of the file. While this is not a critical issue, it's a good practice to include a newline at the end of files to conform to POSIX standards and ensure compatibility with UNIX tools.

**Explicação de Vulnerabilidades:** 
- Not applicable in this context as there are no explicit security vulnerabilities introduced by the changes in the Pull Request. However, it is important to make sure that the logging bucket (`my-logs-bucket`) is secured to prevent unauthorized access to access logs, which can contain sensitive information.